### PR TITLE
Warning: Calling <<-EOS.undent is deprecated!

### DIFF
--- a/Formula/miktex.rb
+++ b/Formula/miktex.rb
@@ -62,7 +62,7 @@ class Miktex < Formula
   end
 
   def caveats
-    msg = <<-EOS.undent
+    msg = <<~EOS.undent
       A bare MiKTeX installation has been set up in #{prefix}.
       Run 'initexmf --report' to view the installation details.
 


### PR DESCRIPTION
Solve the Warning:

```
Warning: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/miktex/homebrew-miktex/Formula/miktex.rb:74:in `caveats'
Please report this to the miktex/miktex tap!
```