### PR TITLE
Possible fix to Issue #10

### DIFF
--- a/Formula/miktex.rb
+++ b/Formula/miktex.rb
@@ -49,7 +49,6 @@ class Miktex < Formula
   def install
     mkdir "build" do
       system "cmake", "..",
-             "-DMIKTEX_MPM_AUTO_ADMIN=t",
              "-DMIKTEX_MPM_AUTO_INSTALL=t",
              "-DMIKTEX_SYSTEM_ETC_FONTS_CONFD_DIR=#{etc}/fonts/conf.d",
              "-DMIKTEX_SYSTEM_VAR_CACHE_DIR=#{var}/cache",


### PR DESCRIPTION
Related to Issue #10. Remove the `MIKTEX_MPM_AUTO_ADMIN` flag so that MiKTeX is installed for the current user as should be by default. This allows on-the-fly installation of packages on my system.