### PR TITLE
fix: update deprecated EOS.undent block

### DIFF
--- a/Formula/miktex.rb
+++ b/Formula/miktex.rb
@@ -54,7 +54,7 @@ class Miktex < Formula
   end
 
   def caveats
-    msg = <<~EOS.undent
+    msg = <<~EOS
       A bare MiKTeX installation has been set up in #{prefix}.
       Run 'initexmf --report' to view the installation details.
 


### PR DESCRIPTION
Reference: https://github.com/Homebrew/brew/issues/3738

**Before:** 
![image](https://user-images.githubusercontent.com/1115741/41276093-0bc530fc-6e5e-11e8-8229-e1cb92f5839c.png)